### PR TITLE
N64 widescreen and dark filter fixes

### DIFF
--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -2258,12 +2258,12 @@ namespace UWUVCI_AIO_WPF
             }
             if (config.WideScreen)
             {
-                mvvm.msg = "Removing Dark Filter...";
+                mvvm.msg = "Enabling Wide Screen...";
                 string filePath = Path.Combine(baseRomPath, "content", "FrameLayout.arc");
                 using (BinaryWriter writer = new BinaryWriter(new FileStream(filePath, FileMode.Open)))
                 {
                     writer.Seek(0x1B0D, SeekOrigin.Begin);
-                    writer.Write(new byte[] { 0xF0 },0,1);
+                    writer.Write(new byte[] { 0x44, 0xF0, 0, 0 }, 0, 4);
                 }
                 mvvm.Progress = 65;
             }
@@ -2274,7 +2274,8 @@ namespace UWUVCI_AIO_WPF
                 using (BinaryWriter writer = new BinaryWriter(new FileStream(filePath, FileMode.Open)))
                 {
                     writer.Seek(0x1AD8, SeekOrigin.Begin);
-                    writer.Write(0L);
+                    var dfByte = (byte)1;
+                    writer.Write(dfByte);
                 }
                 mvvm.Progress = 70;
             }

--- a/UWUVCI AIO WPF/UI/Windows/DownloadWait - Kopieren.xaml.cs
+++ b/UWUVCI AIO WPF/UI/Windows/DownloadWait - Kopieren.xaml.cs
@@ -313,10 +313,11 @@ namespace UWUVCI_AIO_WPF.UI.Windows
                 s.Close();
             }
            mvm.msg = "Setting up Nintendon't...";
-            if (File.Exists(driveletter + "\\nincfg.bin"))
-            {
-                File.Delete(driveletter + "\\nincfg.bin");
-            }
+            if (!File.Exists(driveletter + "\\nincfg.bin"))
+               
+                {
+                    File.Copy(@"bin\tempsd\nintendont\nincfg.bin", driveletter + @"\nincfg.bin");
+                }
 
             if (!Directory.Exists(driveletter + "\\apps\\nintendont"))
             {


### PR DESCRIPTION
I checked the bytes of my FrameLayout.rsc file and compared it to what UWUVCI is making and I noticed the bytes were different. For some reason, my UWUVCI just keeps freezing so I'm unable to actually inject a game to test. Could someone try an N64 game and see if DarkFilter is removed and Widescreen enabled. This should work with any base, not just F-Zero X. Although, my FrameLayout.rsc file has F-Zero X as the base.