### PR TITLE
Modify reserverd_flag2 for GC injections

### DIFF
--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1294,6 +1294,22 @@ namespace UWUVCI_AIO_WPF
             romPath = Path.Combine(tempPath, "game.iso");
             mvvm.Progress = 50;
 
+            //GET ROMCODE and change it
+            mvm.msg = "Trying to save rom code...";
+            //READ FIRST 4 BYTES
+            byte[] chars = new byte[4];
+            FileStream fstrm = new FileStream(romPath, FileMode.Open);
+            fstrm.Read(chars, 0, 4);
+            fstrm.Close();
+            string procod = ByteArrayToString(chars);
+            string metaXml = Path.Combine(baseRomPath, "meta", "meta.xml");
+            XmlDocument doc = new XmlDocument();
+            doc.Load(metaXml);
+            doc.SelectSingleNode("menu/reserved_flag2").InnerText = procod.ToHex();
+            doc.Save(metaXml);
+            //edit emta.xml
+            mvvm.Progress = 55;
+
             mvm.msg = "Replacing TIK and TMD...";
             using (Process extract = new Process())
             {

--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1290,7 +1290,7 @@ namespace UWUVCI_AIO_WPF
 
                 throw new Exception("WIIAn error occured while Creating the ISO");
             }
-            Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
+            //Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
             romPath = Path.Combine(tempPath, "game.iso");
             mvvm.Progress = 50;
 
@@ -1298,7 +1298,7 @@ namespace UWUVCI_AIO_WPF
             mvm.msg = "Trying to save rom code...";
             //READ FIRST 4 BYTES
             byte[] chars = new byte[4];
-            FileStream fstrm = new FileStream(romPath, FileMode.Open);
+            FileStream fstrm = new FileStream(Path.Combine(tempPath, "TempBase", "files", "game.iso"), FileMode.Open);
             fstrm.Read(chars, 0, 4);
             fstrm.Close();
             string procod = ByteArrayToString(chars);
@@ -1308,6 +1308,7 @@ namespace UWUVCI_AIO_WPF
             doc.SelectSingleNode("menu/reserved_flag2").InnerText = procod.ToHex();
             doc.Save(metaXml);
             //edit emta.xml
+            Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
             mvvm.Progress = 55;
 
             mvm.msg = "Replacing TIK and TMD...";

--- a/UWUVCI AIO WPF/Properties/AssemblyInfo.cs
+++ b/UWUVCI AIO WPF/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]

--- a/UWUVCI AIO WPF/UI/Windows/IMG_Message.xaml.cs
+++ b/UWUVCI AIO WPF/UI/Windows/IMG_Message.xaml.cs
@@ -108,6 +108,8 @@ namespace UWUVCI_AIO_WPF.UI.Windows
                 }
                 else
                 {
+                    //This code doesn't work
+                    /* 
                     var image = Pfim.Pfim.FromStream(stream);
                     foreach (var im in WpfImage(image))
                     {
@@ -125,6 +127,12 @@ namespace UWUVCI_AIO_WPF.UI.Windows
                             bitmap.EndInit();
                         }
                     }
+                    */
+
+                    //using old method for .tga
+                    bitmap.BeginInit();
+                    bitmap.UriSource = new Uri(imageURL, UriKind.Absolute);
+                    bitmap.EndInit();
                 }
             }
             catch


### PR DESCRIPTION
It'll make a little confusion for leaving the manual of the base game. Therefore, modify it with corresponding shortened GC game disc id.
Although this won't make it open working manual, i think it's better than popping out the manual for totally unrelated manual like Rhythm Heaven one. (It'll definitely more ideal to disable the manual, but seems to be impossible?)
Also, this makes things like RiiConnect24/UTag#4 able to grab the real GC game id