### PR TITLE
Modify reserved_flag2 for GC injections

### DIFF
--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1294,6 +1294,22 @@ namespace UWUVCI_AIO_WPF
             romPath = Path.Combine(tempPath, "game.iso");
             mvvm.Progress = 50;
 
+            //GET ROMCODE and change it
+            mvm.msg = "Trying to save rom code...";
+            //READ FIRST 4 BYTES
+            byte[] chars = new byte[4];
+            FileStream fstrm = new FileStream(romPath, FileMode.Open);
+            fstrm.Read(chars, 0, 4);
+            fstrm.Close();
+            string procod = ByteArrayToString(chars);
+            string metaXml = Path.Combine(baseRomPath, "meta", "meta.xml");
+            XmlDocument doc = new XmlDocument();
+            doc.Load(metaXml);
+            doc.SelectSingleNode("menu/reserved_flag2").InnerText = procod.ToHex();
+            doc.Save(metaXml);
+            //edit emta.xml
+            mvvm.Progress = 55;
+
             mvm.msg = "Replacing TIK and TMD...";
             using (Process extract = new Process())
             {

--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1290,7 +1290,7 @@ namespace UWUVCI_AIO_WPF
 
                 throw new Exception("WIIAn error occured while Creating the ISO");
             }
-            Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
+            //Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
             romPath = Path.Combine(tempPath, "game.iso");
             mvvm.Progress = 50;
 
@@ -1298,7 +1298,7 @@ namespace UWUVCI_AIO_WPF
             mvm.msg = "Trying to save rom code...";
             //READ FIRST 4 BYTES
             byte[] chars = new byte[4];
-            FileStream fstrm = new FileStream(romPath, FileMode.Open);
+            FileStream fstrm = new FileStream(Path.Combine(tempPath, "TempBase", "files", "game.iso"), FileMode.Open);
             fstrm.Read(chars, 0, 4);
             fstrm.Close();
             string procod = ByteArrayToString(chars);
@@ -1308,6 +1308,7 @@ namespace UWUVCI_AIO_WPF
             doc.SelectSingleNode("menu/reserved_flag2").InnerText = procod.ToHex();
             doc.Save(metaXml);
             //edit emta.xml
+            Directory.Delete(Path.Combine(tempPath, "TempBase"), true);
             mvvm.Progress = 55;
 
             mvm.msg = "Replacing TIK and TMD...";


### PR DESCRIPTION
It'll make a little confusion for leaving the manual of the base game. Therefore, modify it with corresponding shortened GC game disc id.
Although this won't make it able to open a working manual, i think it's better than popping out the manual for totally unrelated title like Rhythm Heaven. (It'll definitely more ideal to disable the manual, but seems to be impossible?)
Also, this makes things like RiiConnect24/UTag#4 able to grab the real GC game id.