### PR TITLE
Injection Fixes

### DIFF
--- a/UWUVCI AIO WPF.sln
+++ b/UWUVCI AIO WPF.sln
@@ -8,13 +8,25 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|x64.ActiveCfg = Debug|x64
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|x64.Build.0 = Debug|x64
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|x86.ActiveCfg = Debug|x86
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Debug|x86.Build.0 = Debug|x86
 		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|x64.ActiveCfg = Release|x64
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|x64.Build.0 = Release|x64
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|x86.ActiveCfg = Release|x86
+		{6A60AB0E-4597-4ECA-AEFB-D63A26CA7B54}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UWUVCI AIO WPF/App.config
+++ b/UWUVCI AIO WPF/App.config
@@ -49,6 +49,9 @@
             <setting name="gczw" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="Ancast" serializeAs="String">
+                <value />
+            </setting>
         </UWUVCI_AIO_WPF.Properties.Settings>
     </userSettings>
   <runtime>

--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1624,21 +1624,24 @@ namespace UWUVCI_AIO_WPF
             mvm.Progress = 40;
             mvm.msg = "Packing...";
 
-            if (Environment.Is64BitOperatingSystem)
-                CNUSPACKER.Program.Main(new string[] { "-in", baseRomPath, "-out", outputPath, "-encryptKeyWidth", Settings.Default.Ckey });
+            using var cnuspacker = new Process();
+            if (!mvm.debug)
+            {
+                cnuspacker.StartInfo.UseShellExecute = false;
+                cnuspacker.StartInfo.CreateNoWindow = true;
+            }
+            if (false)
+            {
+                cnuspacker.StartInfo.FileName = Path.Combine(toolsPath, "CNUSPACKER.exe");
+                cnuspacker.StartInfo.Arguments = $"-in \"{baseRomPath}\" -out \"{outputPath}\" -encryptKeyWith {Properties.Settings.Default.Ckey}";
+            }
             else
             {
-                using var cnuspacker = new Process();
-                if (!mvm.debug)
-                {
-                    cnuspacker.StartInfo.UseShellExecute = false;
-                    cnuspacker.StartInfo.CreateNoWindow = true;
-                }
                 cnuspacker.StartInfo.FileName = "java";
-                cnuspacker.StartInfo.Arguments = $"-jar \"{Path.Combine(toolsPath, "NUSPacker.jar")}\" -in \"{baseRomPath}\" -out \"{outputPath}\" -encryptKeyWith {Settings.Default.Ckey}";
-                cnuspacker.Start();
-                cnuspacker.WaitForExit();
+                cnuspacker.StartInfo.Arguments = $"-jar \"{Path.Combine(toolsPath, "NUSPacker.jar")}\" -in \"{baseRomPath}\" -out \"{outputPath}\" -encryptKeyWith {Properties.Settings.Default.Ckey}";
             }
+            cnuspacker.Start();
+            cnuspacker.WaitForExit();
             mvm.Progress = 90;
             mvm.msg = "Cleaning...";
             Clean();
@@ -2416,7 +2419,7 @@ namespace UWUVCI_AIO_WPF
                             CopyAndConvertImage(Path.Combine(toolsPath, "bootTvTex.png"), Path.Combine(imgPath), false, 1280, 720, 24, "bootTvTex.tga");
                             usetemp = true;
                         }
-                            Images.Add(fileExists);
+                        Images.Add(fileExists);
                     }
                 }
                 else
@@ -2481,7 +2484,7 @@ namespace UWUVCI_AIO_WPF
 
                                 File.Copy(Path.Combine(tempPath, "bootTvTex.png"), Path.Combine(tempPath, "bootDrcTex.png"));
 
-                                if (File.Exists(Path.Combine(tempPath, "bootTvTex.png"))) 
+                                if (File.Exists(Path.Combine(tempPath, "bootTvTex.png")))
                                     File.Delete(Path.Combine(tempPath, "bootTvTex.png"));
 
                                 if (File.Exists($"bootTvTex.{config.TGATv.extension}"))
@@ -2583,13 +2586,15 @@ namespace UWUVCI_AIO_WPF
             }
             catch (Exception e)
             {
-                if (e.Message.Contains("Size"))
+                if (!e.Message.Contains("Could not find"))
                 {
-                    throw e;
+                    if (e.Message.Contains("Size"))
+                    {
+                        throw e;
+                    }
+                    throw new Exception("Images");
                 }
-                throw new Exception("Images");
             }
-
         }
 
         private static void CopyAndConvertImage(string inputPath, string outputPath, bool delete, int widht, int height, int bit, string newname)

--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -2165,7 +2165,7 @@ namespace UWUVCI_AIO_WPF
 
             using (var stream = new FileStream(zipLocation, FileMode.Create))
             using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
-                archive.CreateEntryFromFile(romPath, Path.GetFileNameWithoutExtension(romPath));
+                archive.CreateEntryFromFile(romPath, Path.GetFileName(romPath));
 
             mvvm.Progress = 80;
             File.Delete(RomName);

--- a/UWUVCI AIO WPF/Classes/ToolCheck.cs
+++ b/UWUVCI AIO WPF/Classes/ToolCheck.cs
@@ -12,7 +12,7 @@ namespace UWUVCI_AIO_WPF.Classes
     class ToolCheck
     {
         static string FolderName = new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location).DirectoryName + "\\bin\\Tools";
-        public static string backupulr = @"https://github.com/Hotbrawl20/UWUVCI-Tools/raw/master/" + (Environment.Is64BitProcess ? "x64/" : "");
+        public static string backupulr = @"https://github.com/Hotbrawl20/UWUVCI-Tools/raw/master/";
         public static string[] ToolNames =
         {
             "N64Converter.exe",
@@ -54,7 +54,8 @@ namespace UWUVCI_AIO_WPF.Classes
             "font2.ttf",
             "forwarder.dol",
             "gba1.zip",
-            "gba2.zip"
+            "gba2.zip",
+            "CNUSPACKER.exe"
         };
 
         public static bool DoesToolsFolderExist()

--- a/UWUVCI AIO WPF/Models/MainViewModel.cs
+++ b/UWUVCI AIO WPF/Models/MainViewModel.cs
@@ -486,7 +486,7 @@ namespace UWUVCI_AIO_WPF
         }
         public MainViewModel()
         {
-            if (!Environment.Is64BitOperatingSystem)
+            if (true)
             {
                 List<string> Tools = ToolCheck.ToolNames.ToList();
                 Tools.Add("NUSPacker.jar");

--- a/UWUVCI AIO WPF/Properties/AssemblyInfo.cs
+++ b/UWUVCI AIO WPF/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.99.0.0")]
-[assembly: AssemblyFileVersion("3.99.0.0")]
+[assembly: AssemblyVersion("3.99.0.1")]
+[assembly: AssemblyFileVersion("3.99.0.1")]

--- a/UWUVCI AIO WPF/Properties/Settings.Designer.cs
+++ b/UWUVCI AIO WPF/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace UWUVCI_AIO_WPF.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -176,6 +176,18 @@ namespace UWUVCI_AIO_WPF.Properties {
             }
             set {
                 this["gczw"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Ancast {
+            get {
+                return ((string)(this["Ancast"]));
+            }
+            set {
+                this["Ancast"] = value;
             }
         }
     }

--- a/UWUVCI AIO WPF/Properties/Settings.settings
+++ b/UWUVCI AIO WPF/Properties/Settings.settings
@@ -41,5 +41,8 @@
     <Setting Name="gczw" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="Ancast" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/UWUVCI AIO WPF/UI/Frames/InjectFrames/Configurations/WiiConfig.xaml.cs
+++ b/UWUVCI AIO WPF/UI/Frames/InjectFrames/Configurations/WiiConfig.xaml.cs
@@ -170,6 +170,7 @@ namespace UWUVCI_AIO_WPF.UI.Frames.InjectFrames.Configurations
                     gamepad.ItemsSource = gpEmu;
                     mvm.RomPath = path;
                     mvm.RomSet = true;
+                    ancastKey.Text = Settings.Default.Ancast;
                     if (mvm.BaseDownloaded)
                     {
                         mvm.CanInject = true;
@@ -348,6 +349,7 @@ namespace UWUVCI_AIO_WPF.UI.Frames.InjectFrames.Configurations
 
                 if (hash == "31-8D-1F-9D-98-FB-08-E7-7C-7F-E1-77-AA-49-05-43")
                 {
+                    Settings.Default.Ancast = ancastKey.Text;
                     string[] ancastKeyCopy = { ancastKey.Text };
 
                     Task.Run(() =>

--- a/UWUVCI AIO WPF/UI/Frames/SettingsFrame.xaml
+++ b/UWUVCI AIO WPF/UI/Frames/SettingsFrame.xaml
@@ -46,7 +46,7 @@
         <Ellipse Fill="#FF2196F3" HorizontalAlignment="Left" Height="21" Margin="12,7,0,0" VerticalAlignment="Top" Width="17"/>
         <Ellipse Fill="#FF2196F3" HorizontalAlignment="Left" Height="21" Margin="12,7,0,0" VerticalAlignment="Top" Width="17"/>
         <Border BorderBrush="#FF2196F3" BorderThickness="1" HorizontalAlignment="Left" Height="33" Margin="12,6,0,0" VerticalAlignment="Top" Width="1108" CornerRadius="5" Background="#FF2196F3"/>
-        <Label Content="v3.99.0" HorizontalAlignment="Left" Margin="1075,10,0,0" VerticalAlignment="Top" Foreground="#DDFFFFFF" Width="81" Height="24"/>
+        <Label Content="v3.99.0.1" HorizontalAlignment="Left" Margin="1075,10,0,0" VerticalAlignment="Top" Foreground="#DDFFFFFF" Width="81" Height="24"/>
         <Button HorizontalAlignment="Left" Margin="32,522,0,0" VerticalAlignment="Top" Width="74" Click="Button_Click_13" IsTabStop="False" Height="58" ToolTip="Support UWUVCI on Ko-Fi">
             <Image HorizontalAlignment="Left" Height="46" VerticalAlignment="Top" Width="46" Source="/UI/Images/61e111774d3a2f67c827cd25_Frame 5.png" />
         </Button>

--- a/UWUVCI AIO WPF/UI/Frames/StartFrame.xaml
+++ b/UWUVCI AIO WPF/UI/Frames/StartFrame.xaml
@@ -8,7 +8,7 @@
       d:DesignHeight="480" d:DesignWidth="1130"
       Title="SettingsFrame" >
     <Grid>
-        <TextBlock x:Name="tb" Margin="10,172,10,192" TextWrapping="Wrap" Text="Welcome to UWUVCI AIO v3.99.0. To start Injecting select a Console to your left." FontSize="20" Height="116" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" Width="1110" />
+        <TextBlock x:Name="tb" Margin="10,172,10,192" TextWrapping="Wrap" Text="Welcome to UWUVCI AIO v3.99.0.1. To start Injecting select a Console to your left." FontSize="20" Height="116" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" Width="1110" />
         <TextBlock Margin="15,505,15,0" HorizontalAlignment="Right" VerticalAlignment="Top" Text="Support MAC Development" TextAlignment="Right"></TextBlock>
         <Button HorizontalAlignment="Right" Margin="15,525,15,0" VerticalAlignment="Top" Width="74" Click="Button_Click" IsTabStop="False" Height="58" ToolTip="Support UWUVCI MAC Development on Ko-Fi">
             <Image HorizontalAlignment="Left" Height="46" VerticalAlignment="Top" Width="46" Source="/UI/Images/61e111774d3a2f67c827cd25_Frame 5.png" />

--- a/UWUVCI AIO WPF/UI/Windows/MenuWindow.xaml.cs
+++ b/UWUVCI AIO WPF/UI/Windows/MenuWindow.xaml.cs
@@ -514,7 +514,7 @@ namespace UWUVCI_AIO_WPF
                 var p = new Process();
                 var fileName = Application.ResourceAssembly.Location;
                 foreach (var file in Directory.GetFiles(Directory.GetCurrentDirectory(), "*.exe"))
-                    if (!Path.GetFileName(file).Contains(Path.GetFileNameWithoutExtension(fileName)))
+                    if (Path.GetFileName(file).Contains("vWii"))
                     {
                         fileName = file;
                         break;

--- a/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
+++ b/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
@@ -159,7 +159,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CDecryptSharp" Version="1.0.4" />
-    <PackageReference Include="CNUSPACKER" Version="1.0.4" />
+    <PackageReference Include="CNUSPACKER" Version="1.0.3" />
     <PackageReference Include="GMWare.M2" Version="1.1.2" />
     <PackageReference Include="Json.Net" Version="1.0.33" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.1" />

--- a/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
+++ b/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
@@ -21,6 +21,7 @@
     <UseWindowsForms>True</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <PropertyGroup>
     <SignManifests>false</SignManifests>
@@ -33,7 +34,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>UWUVCI_AIO_WPF.App</StartupObject>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="GameBaseClassLibrary">


### PR DESCRIPTION
Problems with OS Compatibility (????) for Injects using exe's have been fixed.
NDS will correctly name the rom that's being used which will fix the inject.
Fixed WUP Installable using an older version of the packing tool as a hotfix.
Ancast will be stored and used sometimes (limited functionality).