### PR TITLE
use local GameBaseLibrary if the "uwuvci_installer_creator" directory doesn't exist

### DIFF
--- a/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
+++ b/UWUVCI AIO WPF/UWUVCI AIO WPF.csproj
@@ -76,7 +76,8 @@
       <HintPath>..\packages\CDecryptSharp.1.0.4\lib\CSharpDecrypt.dll</HintPath>
     </Reference>
     <Reference Include="GameBaseClassLibrary">
-      <HintPath>..\..\..\uwuvci_installer_creator\{app}\GameBaseClassLibrary.dll</HintPath>
+      <HintPath Condition="Exists('..\..\..\uwuvci_installer_creator\{app}\')">..\..\..\uwuvci_installer_creator\{app}\GameBaseClassLibrary.dll</HintPath>
+      <HintPath>GameBaseClassLibrary.dll</HintPath>
     </Reference>
     <Reference Include="GMWare.M2, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\GMWare.M2.1.1.2\lib\netstandard2.0\GMWare.M2.dll</HintPath>


### PR DESCRIPTION
Had a little trouble getting it to build and found that this was the culprit. I've never used C# or Visual Studio, but it looks like this is the way to solve the problem and let it build just from cloning the repo.