### PR TITLE
Add console name to folder and space after brackets

### DIFF
--- a/UWUVCI AIO WPF/Classes/Injection.cs
+++ b/UWUVCI AIO WPF/Classes/Injection.cs
@@ -1624,19 +1624,19 @@ namespace UWUVCI_AIO_WPF
             }
         }
         [STAThread]
-        public static void Loadiine(string gameName)
+        public static void Loadiine(string gameName, string gameConsole)
         {
             if (gameName == null || gameName == string.Empty) gameName = "NoName";
             gameName = gameName.Replace("|", " ");
             Regex reg = new Regex("[^a-zA-Z0-9 é -]");
             //string outputPath = Path.Combine(Properties.Settings.Default.InjectionPath, gameName);
-            string outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[LOADIINE]{reg.Replace(gameName,"")} [{mvvm.prodcode}]");
-            mvvm.foldername = $"[LOADIINE]{reg.Replace(gameName, "")} [{mvvm.prodcode}]";
+            string outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[LOADIINE][{gameConsole}] {reg.Replace(gameName,"")} [{mvvm.prodcode}]");
+            mvvm.foldername = $"[LOADIINE][{gameConsole}] {reg.Replace(gameName, "")} [{mvvm.prodcode}]";
             int i = 0;
             while (Directory.Exists(outputPath))
             {
-                outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[LOADIINE]{reg.Replace(gameName, "")} [{mvvm.prodcode}]_{i}");
-                mvvm.foldername = $"[LOADIINE]{reg.Replace(gameName, "")} [{mvvm.prodcode}]_{i}";
+                outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[LOADIINE][{gameConsole}] {reg.Replace(gameName, "")} [{mvvm.prodcode}]_{i}");
+                mvvm.foldername = $"[LOADIINE][{gameConsole}] {reg.Replace(gameName, "")} [{mvvm.prodcode}]_{i}";
                 i++;
             }
             
@@ -1654,7 +1654,7 @@ namespace UWUVCI_AIO_WPF
             Clean();
         }
         [STAThread]
-        public static void Packing(string gameName, MainViewModel mvm)
+        public static void Packing(string gameName, string gameConsole, MainViewModel mvm)
         {
             mvm.msg = "Checking Tools...";
             mvm.InjcttoolCheck();
@@ -1664,14 +1664,14 @@ namespace UWUVCI_AIO_WPF
             if (gameName == null || gameName == string.Empty) gameName = "NoName";
            
             //string outputPath = Path.Combine(Properties.Settings.Default.InjectionPath, gameName);
-            string outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[WUP]{reg.Replace(gameName,"").Replace("|", " ")}");
+            string outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[WUP][{gameConsole}] {reg.Replace(gameName,"").Replace("|", " ")}");
             outputPath = outputPath.Replace("|", " ");
-            mvvm.foldername = $"[WUP]{reg.Replace(gameName, "").Replace("|"," ")}";
+            mvvm.foldername = $"[WUP][{gameConsole}] {reg.Replace(gameName, "").Replace("|"," ")}";
             int i = 0;
             while (Directory.Exists(outputPath))
             {
-                outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[WUP]{reg.Replace(gameName,"").Replace("|", " ")}_{i}");
-                mvvm.foldername = $"[WUP]{reg.Replace(gameName, "").Replace("|", " ")}_{i}";
+                outputPath = Path.Combine(Properties.Settings.Default.OutPath, $"[WUP][{gameConsole}] {reg.Replace(gameName,"").Replace("|", " ")}_{i}");
+                mvvm.foldername = $"[WUP][{gameConsole}] {reg.Replace(gameName, "").Replace("|", " ")}_{i}";
                 i++;
             }
             var oldpath = Directory.GetCurrentDirectory();

--- a/UWUVCI AIO WPF/Models/MainViewModel.cs
+++ b/UWUVCI AIO WPF/Models/MainViewModel.cs
@@ -1006,10 +1006,17 @@ namespace UWUVCI_AIO_WPF
         }
         public void Pack(bool loadiine)
         {
+            string consoleName =  GameConfiguration.Console.ToString();
+
+            if (GC)
+            {
+                consoleName = GameConsoles.GCN.ToString();
+            }
+
             ValidatePathsStillExist();
             if (loadiine)
             {
-                Injection.Loadiine(GameConfiguration.GameName);
+                Injection.Loadiine(GameConfiguration.GameName, consoleName);
                 //
             }
             else
@@ -1021,7 +1028,7 @@ namespace UWUVCI_AIO_WPF
                     gameConfiguration.GameName = reg.Replace(gameConfiguration.GameName, "");
                 }
 
-                Task.Run(() => { Injection.Packing(GameConfiguration.GameName, this); });
+                Task.Run(() => { Injection.Packing(GameConfiguration.GameName, consoleName, this); });
 
                 DownloadWait dw = new DownloadWait("Packing Inject - Please Wait", "", this);
                 try


### PR DESCRIPTION
Small change to add the game console designation to the folder name and spacing after the bracket. 
Example w/ Nintendo64:
`[WUP]Game Title` => `[WUP][N64] Game Title`